### PR TITLE
Add ability to change colors through Add-On config in Anki

### DIFF
--- a/button_colours/__init__.py
+++ b/button_colours/__init__.py
@@ -1,16 +1,18 @@
 # Author: C9HDN
 # Get reviewer class
 from aqt.reviewer import Reviewer
+from aqt import mw
 
 # Replace _answerButtonList method
 def answerButtonList(self):
-    l = ((1, "<font color='red'>" + _("Again") + "</font>"),)
+    config = mw.addonManager.getConfig(__name__)
+    l = ((1, "<font color='"+config['Again']+"'>" + _("Again") + "</font>"),)
     cnt = self.mw.col.sched.answerButtons(self.card)
     if cnt == 2:
-        return l + ((2, "<font color='green'>" + _("Good") + "</font>"),)
+        return l + ((2, "<font color='"+config['Good (2 Answers)']+"'>" + _("Good") + "</font>"),)
     elif cnt == 3:
-        return l + ((2, "<font color='green'>" + _("Good") + "</font>"), (3, "<font color='blue'>" + _("Easy") + "</font>"))
+        return l + ((2, "<font color='"+config['Good (3 Answers)']+"'>" + _("Good") + "</font>"), (3, "<font color='"+config['Easy (3 Answers)']+"'>" + _("Easy") + "</font>"))
     else:
-        return l + ((2, _("Hard")), (3, "<font color='green'>" + _("Good") + "</font>"), (4, "<font color='blue'>" + _("Easy") + "</font>"))
+        return l + ((2, "<font color='"+config['Hard']+"'>" + _("Hard") + "</font>"), (3, "<font color='"+config['Good (4 Answers)']+"'>" + _("Good") + "</font>"), (4, "<font color='"+config['Easy (4 Answers)']+"'>" + _("Easy") + "</font>"))
 
 Reviewer._answerButtonList = answerButtonList

--- a/button_colours/config.json
+++ b/button_colours/config.json
@@ -1,0 +1,7 @@
+{"Again": "Red",
+"Hard" : "Orange",	
+"Good (2 Answers)": "Green",
+"Good (3 Answers)": "Yellow",
+"Good (4 Answers)": "Yellow",
+"Easy (3 Answers)": "Green",
+"Easy (4 Answers)": "Green"}


### PR DESCRIPTION
This should allow 2.1 users to go into the Add-On page and change colors using the config.json file.
![Screen Shot 2019-05-24 at 5 18 01 PM](https://user-images.githubusercontent.com/19899541/58362089-20876500-7e48-11e9-8b46-480ae56cc889.png)
![Screen Shot 2019-05-24 at 5 18 08 PM](https://user-images.githubusercontent.com/19899541/58362072-0057a600-7e48-11e9-91fc-8608f92acd23.png)
